### PR TITLE
docs(apifortress) improve documentation

### DIFF
--- a/app/_data/plugins.yml
+++ b/app/_data/plugins.yml
@@ -56,6 +56,9 @@
     - name: Runscope
       info: API Performance Testing and Monitoring
 
+    - name: API Fortress
+      info: Interface with your API Fortress monitoring setup
+
 - name: Transformations
   info: Transform request and responses on the fly on Kong
   plugins:

--- a/app/plugins/apifortress.md
+++ b/app/plugins/apifortress.md
@@ -6,34 +6,31 @@ header_icon: /assets/images/icons/plugins/apifortress.png
 breadcrumbs:
   Plugins: /plugins
 nav:
+  - label: Configuration
   - label: Getting Started
     items:
       - label: How it works
-      - label: Configuration
+      - label: Notes
 ---
-This plugin forward s serialized request / response bundles to the [API Fortress] platform for full payload testing. Send the bundles to API Fortress in the **cloud** or the **on-prem engine instance**.
 
-Create the tests in the API Fortress visual composer. Tests can verify every detail of an API conversation - including request and response headers, and every field in an XML, JSON, or plain text payload.
-
-If a test fails, you will be notified via email, SMS, or any 3rd party app you configure in the API Fortress dashboard.
-
-Use different projects for different environments to host tests for development, staging, or production. Select which by configuring the Kong plugin.
+This plugin forwards serialized request/response bundles to the [API Fortress]
+platform for full payload testing.
 
 ----
 
 ## How it works
 
-The plugin sends serialized traffic to your API Fortress account, identified by an api key.
-The number of bundles being sent can be limited during configuration by setting the threshold key.
-In the configuration you're also allowed to select the project that will host the tests.
+The plugin sends serialized traffic to your API Fortress account, identified by
+an api key.  The number of bundles being sent can be limited during
+configuration by setting the threshold key.  In the configuration you're also
+allowed to select the project that will host the tests.
 
-For each bundle, API Fortress will choose which tests need to run, using the [Automatch] pattern configuration against the origin URL.
+For each bundle, API Fortress will choose which tests need to run, using the
+[Automatch] pattern configuration against the origin URL.
 
 ----
 
 ## Configuration
-
-
 
 ```bash
 $ curl -X POST http://kong:8001/apis/{api}/plugins/ \
@@ -45,16 +42,15 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins/ \
     --data "config.threshold=THRESHOLD_SETTING"
 ```
 
-
-
 parameter                          | description
 ---                                | ---
-`name`                             | The name of the plugin
-`config.endpoint`                  | The endpoint to send the requests to. The default for the cloud service is `https://mastiff.apifortress.com/app/api/rest/v2/test/runAutomatch`
-`config.apikey`                    | Identifies your company in API Fortress
-`config.secret`                    | Works as a cypher passphrase
-`config.projectId`                 | The id of the project hosting the tests
-`config.threshold`                 | A number working as a limit to the number of forwarded bundles. Every multiple of `threshold` will be sent. Ie. if threshold is 3, then the 3rd, 6th, 9th are sent
+`name`                             | The name of the plugin to use, in this case: `apifortress`.
+`consumer_id`<br>*optional*        | The CONSUMER ID that this plugin configuration will target. This value can only be used if [authentication has been enabled][faq-authentication] so that the system can identify the user making the request.
+`config.endpoint`<br/>*optional*   | Default: `https://mastiff.apifortress.com/app/api/rest/v2/test/runAutomatch`. The endpoint to send the requests to.
+`config.apikey`                    | Identifies your company in API Fortress.
+`config.secret`                    | Works as a cypher passphrase.
+`config.projectId`                 | The id of the project hosting the tests.
+`config.threshold`                 | A number working as a limit to the number of forwarded bundles. Every multiple of `threshold` will be sent. Ie, if threshold is 3, then the 3rd, 6th, 9th are sent.
 
 ----
 ## Notes
@@ -63,3 +59,5 @@ parameter                          | description
 
 [API Fortress]: http://apifortress.com
 [Automatch]: http://apifortress.com/doc/automatch/
+[faq-authentication]: /about/faq/#how-can-i-add-an-authentication-layer-on-a-microservice/api?
+


### PR DESCRIPTION
Would you agree with those changes? Assuming the `config.endpoint` property does get a default value as suggested in Mashape/kong#1093.

- Add to Plugins Gallery
- Top sentence is only for short intro
- 80 width
- Proper syntax for `config.endpoint`'s default value